### PR TITLE
Feed through collection type to transactions

### DIFF
--- a/Turf.xcodeproj/project.pbxproj
+++ b/Turf.xcodeproj/project.pbxproj
@@ -85,11 +85,11 @@
 		7277F5481C4C01040081118D /* SQLiteCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7277F5471C4C01040081118D /* SQLiteCollection.swift */; };
 		727B02481CA55B3B006D245A /* WhereClause.swift in Sources */ = {isa = PBXBuildFile; fileRef = 727B02471CA55B3B006D245A /* WhereClause.swift */; };
 		727B024A1CA56BC5006D245A /* WhereClauses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 727B02491CA56BC5006D245A /* WhereClauses.swift */; };
-		72856A391CBA898000700650 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72856A371CBA898000700650 /* Nimble.framework */; };
-		72856A3A1CBA898000700650 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72856A381CBA898000700650 /* Quick.framework */; };
 		728C235C1C3B121E0033D986 /* CacheUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728C235B1C3B121E0033D986 /* CacheUpdates.swift */; };
 		72B616E41BAF474A00CFE67C /* Turf.h in Headers */ = {isa = PBXBuildFile; fileRef = 72B616E31BAF474A00CFE67C /* Turf.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		72CC14631C271A2A0048F331 /* TypeErasedCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CC14621C271A2A0048F331 /* TypeErasedCollection.swift */; };
+		72D10FE01CBBEF8800401FFE /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72D10FDE1CBBEF8800401FFE /* Nimble.framework */; };
+		72D10FE11CBBEF8800401FFE /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72D10FDF1CBBEF8800401FFE /* Quick.framework */; };
 		72E1D9DF1C260C4B007335A1 /* SQLStatementCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72E1D9DE1C260C4B007335A1 /* SQLStatementCache.swift */; };
 		72E7F4EA1C3433D9009C1D9D /* SQLiteError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72E7F4E91C3433D9009C1D9D /* SQLiteError.swift */; };
 		72F6F7001C24622A0059D72C /* ExtendedCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72F6F6FF1C24622A0059D72C /* ExtendedCollection.swift */; };
@@ -185,13 +185,13 @@
 		7277F5471C4C01040081118D /* SQLiteCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLiteCollection.swift; sourceTree = "<group>"; };
 		727B02471CA55B3B006D245A /* WhereClause.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhereClause.swift; sourceTree = "<group>"; };
 		727B02491CA56BC5006D245A /* WhereClauses.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhereClauses.swift; sourceTree = "<group>"; };
-		72856A371CBA898000700650 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
-		72856A381CBA898000700650 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		728C235B1C3B121E0033D986 /* CacheUpdates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CacheUpdates.swift; sourceTree = "<group>"; };
 		72B616E01BAF474A00CFE67C /* Turf.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Turf.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		72B616E31BAF474A00CFE67C /* Turf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Turf.h; sourceTree = "<group>"; };
 		72B616E51BAF474A00CFE67C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		72CC14621C271A2A0048F331 /* TypeErasedCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeErasedCollection.swift; sourceTree = "<group>"; };
+		72D10FDE1CBBEF8800401FFE /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
+		72D10FDF1CBBEF8800401FFE /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		72D37B7E1BC326770087153A /* iOS.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = iOS.modulemap; sourceTree = "<group>"; };
 		72E1D9DE1C260C4B007335A1 /* SQLStatementCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLStatementCache.swift; sourceTree = "<group>"; };
 		72E7F4E91C3433D9009C1D9D /* SQLiteError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLiteError.swift; sourceTree = "<group>"; };
@@ -203,8 +203,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				72856A391CBA898000700650 /* Nimble.framework in Frameworks */,
-				72856A3A1CBA898000700650 /* Quick.framework in Frameworks */,
+				72D10FE01CBBEF8800401FFE /* Nimble.framework in Frameworks */,
+				72D10FE11CBBEF8800401FFE /* Quick.framework in Frameworks */,
 				724E75BB1CA945270082841B /* Turf.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -442,8 +442,8 @@
 		72B616D61BAF474A00CFE67C = {
 			isa = PBXGroup;
 			children = (
-				72856A371CBA898000700650 /* Nimble.framework */,
-				72856A381CBA898000700650 /* Quick.framework */,
+				72D10FDE1CBBEF8800401FFE /* Nimble.framework */,
+				72D10FDF1CBBEF8800401FFE /* Quick.framework */,
 				726D24521C767D5C003CE68C /* libsqlite3.tbd */,
 				72B616E21BAF474A00CFE67C /* Turf */,
 				724E75B71CA945270082841B /* TurfRegressionTests */,
@@ -728,6 +728,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
 				);
 				INFOPLIST_FILE = TurfRegressionTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
@@ -744,6 +745,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
 				);
 				INFOPLIST_FILE = TurfRegressionTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;

--- a/Turf/Collection/Collection.swift
+++ b/Turf/Collection/Collection.swift
@@ -43,5 +43,5 @@ public protocol Collection: class, TypeErasedCollection {
      - warning: You must call `transaction.registerCollection(self)`
      - parameter transaction
      */
-    func setUp(transaction: ReadWriteTransaction) throws
+    func setUp<DatabaseCollections: CollectionsContainer>(transaction: ReadWriteTransaction<DatabaseCollections>) throws
 }

--- a/Turf/Collection/Internals/CollectionLocalStorage.swift
+++ b/Turf/Collection/Internals/CollectionLocalStorage.swift
@@ -81,10 +81,10 @@ internal class CollectionLocalStorage<Value>: TypeErasedCollectionLocalStorage {
         Dispatch.asynchronouslyOn(Dispatch.Queues.Main) {
             NSNotificationCenter.defaultCenter()
                 .postNotificationName(
-                    Database.CollectionChangedNotification,
+                    CollectionChangedNotification,
                     object: collection,
                     userInfo: [
-                        Database.CollectionChangedNotificationChangeSetKey: changeSetCopy
+                        CollectionChangedNotificationChangeSetKey: changeSetCopy
                     ])
         }
 
@@ -100,7 +100,7 @@ internal class CollectionLocalStorage<Value>: TypeErasedCollectionLocalStorage {
      - parameter database: The database changes were made on
      - parameter snapshot: The connection's snapshot number at which the changes were made
      */
-    func recordPendingCacheUpdatesOnSnapshot(snapshot: UInt64, withDatabase database: Database){
+    func recordPendingCacheUpdatesOnSnapshot<DatabaseCollections: CollectionsContainer>(snapshot: UInt64, withDatabase database: Database<DatabaseCollections>) {
         database.recordPendingCacheUpdates(cacheUpdates.copy(), onSnapshot: snapshot, forCollectionNamed: collectionName)
     }
 
@@ -113,9 +113,9 @@ internal class CollectionLocalStorage<Value>: TypeErasedCollectionLocalStorage {
      - parameter maxSnapshot: upper bound snapshot number
      - parameter database: The database the cache updates were recorded on
      */
-    func applyChangeSetsToValueCacheAfterSnapshot(minSnapshot: UInt64, upToSnapshot: UInt64, withDatabase database: Database) {
+    func applyChangeSetsToValueCacheAfterSnapshot<DatabaseCollections: CollectionsContainer>(minSnapshot: UInt64, upToSnapshot maxSnapshot: UInt64, withDatabase database: Database<DatabaseCollections>) {
         let cacheChanges: CacheUpdates<String, Value> = database
-            .cacheChangesAfterSnapshot(minSnapshot, upToSnapshot: upToSnapshot, forCollectionNamed: collectionName)
+            .cacheChangesAfterSnapshot(minSnapshot, upToSnapshot: maxSnapshot, forCollectionNamed: collectionName)
         cacheChanges.applyUpdatesToCache(valueCache)
     }
 }

--- a/Turf/Collection/Internals/TypeErasedCollection.swift
+++ b/Turf/Collection/Internals/TypeErasedCollection.swift
@@ -13,9 +13,3 @@ public protocol TypeErasedCollection: class {
      */
     func setUp<DatabaseCollections: CollectionsContainer>(transaction: ReadWriteTransaction<DatabaseCollections>) throws
 }
-
-//internal extension TypeErasedCollection where Self: Collection {
-//    func readOnly(transaction: ReadTransaction) -> ReadCollection<Self> {
-//        return ReadCollection(collection: self, transaction: transaction)
-//    }
-//}

--- a/Turf/Collection/Internals/TypeErasedCollection.swift
+++ b/Turf/Collection/Internals/TypeErasedCollection.swift
@@ -11,11 +11,11 @@ public protocol TypeErasedCollection: class {
     /**
      - parameter transaction
      */
-    func setUp(transaction: ReadWriteTransaction) throws
+    func setUp<DatabaseCollections: CollectionsContainer>(transaction: ReadWriteTransaction<DatabaseCollections>) throws
 }
 
-internal extension TypeErasedCollection where Self: Collection {
-    func readOnly(transaction: ReadTransaction) -> ReadCollection<Self> {
-        return ReadCollection(collection: self, transaction: transaction)
-    }
-}
+//internal extension TypeErasedCollection where Self: Collection {
+//    func readOnly(transaction: ReadTransaction) -> ReadCollection<Self> {
+//        return ReadCollection(collection: self, transaction: transaction)
+//    }
+//}

--- a/Turf/Collection/Internals/TypeErasedCollectionLocalStorage.swift
+++ b/Turf/Collection/Internals/TypeErasedCollectionLocalStorage.swift
@@ -42,7 +42,7 @@ internal protocol TypeErasedCollectionLocalStorage {
      - parameter snapshot: The connection's snapshot number at which the changes were made
      - parameter database: The database changes were made on
      */
-    func recordPendingCacheUpdatesOnSnapshot(snapshot: UInt64, withDatabase database: Database)
+    func recordPendingCacheUpdatesOnSnapshot<DatabaseCollections: CollectionsContainer>(snapshot: UInt64, withDatabase database: Database<DatabaseCollections>)
 
     /**
      Gets all pending and commited cache changes *after* `minSnapshot` up to *and including* `maxSnapshot` from
@@ -53,5 +53,5 @@ internal protocol TypeErasedCollectionLocalStorage {
      - parameter maxSnapshot: upper bound snapshot number
      - parameter database: The database the cache updates were recorded on
      */
-    func applyChangeSetsToValueCacheAfterSnapshot(minSnapshot: UInt64, upToSnapshot maxSnapshot: UInt64, withDatabase database: Database)
+    func applyChangeSetsToValueCacheAfterSnapshot<DatabaseCollections: CollectionsContainer>(minSnapshot: UInt64, upToSnapshot maxSnapshot: UInt64, withDatabase database: Database<DatabaseCollections>)
 }

--- a/Turf/Collection/ReadCollection.swift
+++ b/Turf/Collection/ReadCollection.swift
@@ -1,11 +1,11 @@
-public class ReadCollection<TCollection: Collection>: ReadableCollection {
+public class ReadCollection<TCollection: Collection, DatabaseCollections: CollectionsContainer>: ReadableCollection {
     /// Collection row type
     public typealias Value = TCollection.Value
 
     // MARK: Public properties
 
     /// Reference to read transaction from which this collection reads on
-    public unowned let readTransaction: ReadTransaction
+    public unowned let readTransaction: ReadTransaction<DatabaseCollections>
 
     /// Reference to user defined collection
     public unowned let collection: TCollection
@@ -30,7 +30,7 @@ public class ReadCollection<TCollection: Collection>: ReadableCollection {
      - parameter collection: Collection this read-only view wraps
      - parameter transaction: Read transaction the read-only view reads on
      */
-    internal init(collection: TCollection, transaction: ReadTransaction) {
+    internal init(collection: TCollection, transaction: ReadTransaction<DatabaseCollections>) {
         self.collection = collection
         self.readTransaction = transaction
         self.localStorage = readTransaction.connection.localStorageForCollection(collection)

--- a/Turf/Collection/ReadCollection.swift
+++ b/Turf/Collection/ReadCollection.swift
@@ -1,11 +1,11 @@
-public class ReadCollection<TCollection: Collection, DatabaseCollections: CollectionsContainer>: ReadableCollection {
+public class ReadCollection<TCollection: Collection, Collections: CollectionsContainer>: ReadableCollection {
     /// Collection row type
     public typealias Value = TCollection.Value
 
     // MARK: Public properties
 
     /// Reference to read transaction from which this collection reads on
-    public unowned let readTransaction: ReadTransaction<DatabaseCollections>
+    public unowned let readTransaction: ReadTransaction<Collections>
 
     /// Reference to user defined collection
     public unowned let collection: TCollection
@@ -30,10 +30,12 @@ public class ReadCollection<TCollection: Collection, DatabaseCollections: Collec
      - parameter collection: Collection this read-only view wraps
      - parameter transaction: Read transaction the read-only view reads on
      */
-    internal init(collection: TCollection, transaction: ReadTransaction<DatabaseCollections>) {
+    internal init(collection: TCollection, transaction: ReadTransaction<Collections>) {
         self.collection = collection
         self.readTransaction = transaction
-        self.localStorage = readTransaction.connection.localStorageForCollection(collection)
+        //FIXME segfault
+        let connection: Connection<Collections> = readTransaction.connection
+        self.localStorage = connection.localStorageForCollection(collection)
         self.deserializeValue = collection.deserializeValue
     }
 

--- a/Turf/Collection/ReadWriteCollection.swift
+++ b/Turf/Collection/ReadWriteCollection.swift
@@ -1,8 +1,8 @@
-public final class ReadWriteCollection<TCollection: Collection>: ReadCollection<TCollection>, WritableCollection {
+public final class ReadWriteCollection<TCollection: Collection, DatabaseCollections: CollectionsContainer>: ReadCollection<TCollection, DatabaseCollections>, WritableCollection {
     // MARK: Internal properties
 
     /// Reference to read-write transaction from which this collection operates on
-    internal unowned let readWriteTransaction: ReadWriteTransaction
+    internal unowned let readWriteTransaction: ReadWriteTransaction<DatabaseCollections>
 
     // MARK: Private properties
 
@@ -15,7 +15,7 @@ public final class ReadWriteCollection<TCollection: Collection>: ReadCollection<
      - parameter collection: Collection this read-write view wraps
      - parameter transaction: Read-write transaction the read-write view operates on
     */
-    internal init(collection: TCollection, transaction: ReadWriteTransaction) {
+    internal init(collection: TCollection, transaction: ReadWriteTransaction<DatabaseCollections>) {
         self.readWriteTransaction = transaction
         self.serializeValue = collection.serializeValue
         super.init(collection: collection, transaction: transaction)

--- a/Turf/Collection/ReadWriteCollection.swift
+++ b/Turf/Collection/ReadWriteCollection.swift
@@ -1,8 +1,8 @@
-public final class ReadWriteCollection<TCollection: Collection, DatabaseCollections: CollectionsContainer>: ReadCollection<TCollection, DatabaseCollections>, WritableCollection {
+public final class ReadWriteCollection<TCollection: Collection, Collections: CollectionsContainer>: ReadCollection<TCollection, Collections>, WritableCollection {
     // MARK: Internal properties
 
     /// Reference to read-write transaction from which this collection operates on
-    internal unowned let readWriteTransaction: ReadWriteTransaction<DatabaseCollections>
+    internal unowned let readWriteTransaction: ReadWriteTransaction<Collections>
 
     // MARK: Private properties
 
@@ -15,7 +15,7 @@ public final class ReadWriteCollection<TCollection: Collection, DatabaseCollecti
      - parameter collection: Collection this read-write view wraps
      - parameter transaction: Read-write transaction the read-write view operates on
     */
-    internal init(collection: TCollection, transaction: ReadWriteTransaction<DatabaseCollections>) {
+    internal init(collection: TCollection, transaction: ReadWriteTransaction<Collections>) {
         self.readWriteTransaction = transaction
         self.serializeValue = collection.serializeValue
         super.init(collection: collection, transaction: transaction)
@@ -60,7 +60,9 @@ public final class ReadWriteCollection<TCollection: Collection, DatabaseCollecti
         localStorage.valueCache[key] = value
         localStorage.cacheUpdates.recordValue(value, upsertedWithKey: key)
 
-        readWriteTransaction.connection.recordModifiedCollection(collection)
+        //FIXME segfault
+        let connection: Connection<Collections> = readWriteTransaction.connection
+        connection.recordModifiedCollection(collection)
         return rowChange
     }
 
@@ -71,7 +73,9 @@ public final class ReadWriteCollection<TCollection: Collection, DatabaseCollecti
             localStorage.changeSet.recordValueRemovedWithKey(key)
             localStorage.cacheUpdates.recordValueRemovedWithKey(key)
         }
-        readWriteTransaction.connection.recordModifiedCollection(collection)
+        //FIXME segfault
+        let connection: Connection<Collections> = readWriteTransaction.connection
+        connection.recordModifiedCollection(collection)
     }
 
     private func commonRemoveAllValues() throws {
@@ -79,7 +83,9 @@ public final class ReadWriteCollection<TCollection: Collection, DatabaseCollecti
         localStorage.valueCache.removeAllValues()
         localStorage.changeSet.recordAllValuesRemoved()
         localStorage.cacheUpdates.recordAllValuesRemoved()
-        readWriteTransaction.connection.recordModifiedCollection(collection)
+        //FIXME segfault
+        let connection: Connection<Collections> = readWriteTransaction.connection
+        connection.recordModifiedCollection(collection)
     }
 }
 

--- a/Turf/Core/CollectionsContainer.swift
+++ b/Turf/Core/CollectionsContainer.swift
@@ -20,5 +20,5 @@ public protocol CollectionsContainer {
      Called when initializing a `Database`
      - parameter transaction: Can be used to register new collections and extensions
      */
-    func setUpCollections(transaction transaction: ReadWriteTransaction) throws
+    func setUpCollections(transaction transaction: ReadWriteTransaction<Self>) throws
 }

--- a/Turf/Core/Connection.swift
+++ b/Turf/Core/Connection.swift
@@ -1,10 +1,10 @@
 private let connectionQueueKey = "connectionQueueKey".UTF8String
 
-public final class Connection {
+public final class Connection<DatabaseCollections: CollectionsContainer> {
     // MARK: Public properties
 
     /// Reference to parent database
-    public weak var database: Database!
+    public weak var database: Database<DatabaseCollections>!
 
     /// Default value cache size when a collection does not provide its own size
     public let defaultValueCacheSize: Int
@@ -47,7 +47,7 @@ public final class Connection {
      - parameter defaultValueCacheSize: The default when a collection does not provide its own cache size. Default = 50.
      - throws: SQLiteError.FailedToOpenDatabase or SQLiteError.Error(code, reason)
      */
-    internal init(id: Int, database: Database, databaseWriteQueue: Dispatch.Queue, defaultValueCacheSize: Int = 50) throws {
+    internal init(id: Int, database: Database<DatabaseCollections>, databaseWriteQueue: Dispatch.Queue, defaultValueCacheSize: Int = 50) throws {
         self.id = id
         self.database = database
         self.databaseWriteQueue = databaseWriteQueue
@@ -88,7 +88,7 @@ public final class Connection {
             - `closure` is executed on the connection's queue.
      - parameter closure: Operations to perform within the read transaction.
      */
-    public func readTransaction(closure: ReadTransaction -> Void) throws {
+    public func readTransaction(closure: ReadTransaction<DatabaseCollections> -> Void) throws {
         try Dispatch.synchronouslyOn(connectionQueue) {
             let transaction = ReadTransaction(connection: self)
             try self.preReadTransaction(transaction)
@@ -104,7 +104,7 @@ public final class Connection {
              - `closure` is executed on the connection's queue and global write queue.
      - parameter closure: Operations to perform within the read-write transaction.
      */
-    public func readWriteTransaction(closure: ReadWriteTransaction throws -> Void) throws {
+    public func readWriteTransaction(closure: ReadWriteTransaction<DatabaseCollections> throws -> Void) throws {
         try Dispatch.synchronouslyOn(connectionQueue) {
             try Dispatch.synchronouslyOn(self.databaseWriteQueue) {
                 Dispatch.Queues.setContext(
@@ -131,7 +131,7 @@ public final class Connection {
          - Thread safe
      - warning: Must be called from a read-write transaction
      */
-    func registerExtension<Ext: Extension>(ext: Ext, onTransaction transaction: ReadWriteTransaction) throws {
+    func registerExtension<Ext: Extension>(ext: Ext, onTransaction transaction: ReadWriteTransaction<DatabaseCollections>) throws {
         assert(database.isOnWriteQueue(), "Must be called from a read-write transaction")
         self.database.registerExtension(ext)
 
@@ -211,7 +211,7 @@ public final class Connection {
         **Not thread safe**
      - warning: This must be called from the connection queue.
      */
-    func preReadTransaction(transaction: ReadTransaction) throws {
+    func preReadTransaction(transaction: ReadTransaction<DatabaseCollections>) throws {
         assert(isOnConnectionQueue(), "Must be called from a read transaction")
 
         connectionState = .ActiveReadTransaction
@@ -224,7 +224,7 @@ public final class Connection {
         **Not thread safe**
      - warning: This must be called from the connection queue.
      */
-    func postReadTransaction(transaction: ReadTransaction) throws {
+    func postReadTransaction(transaction: ReadTransaction<DatabaseCollections>) throws {
         assert(isOnConnectionQueue(), "Must be called from a read-write transaction")
 
         try sqlite.commitTransaction()
@@ -239,7 +239,7 @@ public final class Connection {
         **Not thread safe**
      - warning: This must be called from the write queue.
      */
-    private func preReadWriteTransaction(transaction: ReadWriteTransaction) throws {
+    private func preReadWriteTransaction(transaction: ReadWriteTransaction<DatabaseCollections>) throws {
         assert(database.isOnWriteQueue(), "Must be called from write queue")
 
         connectionState = .ActiveReadWriteTransaction
@@ -252,7 +252,7 @@ public final class Connection {
         **Not thread safe**
      - warning: This must be called from the write queue.
      */
-    private func postReadWriteTransaction(transaction: ReadWriteTransaction) throws {
+    private func postReadWriteTransaction(transaction: ReadWriteTransaction<DatabaseCollections>) throws {
         assert(database.isOnWriteQueue(), "Must be called from write queue")
 
         if transaction.shouldRollback {
@@ -297,7 +297,7 @@ public final class Connection {
         - **Not thread safe**
      - warning: This must be called from the write queue.
      */
-    private func rollbackTransaction(transaction: ReadWriteTransaction) throws {
+    private func rollbackTransaction(transaction: ReadWriteTransaction<DatabaseCollections>) throws {
         assert(database.isOnWriteQueue(), "Must be called from write queue")
 
         try sqlite.rollbackTransaction()
@@ -315,7 +315,7 @@ public final class Connection {
         - **Not thread safe**
      - warning: This must be called from the write queue.
      */
-    private func commitWriteTransaction(transaction: ReadWriteTransaction) throws {
+    private func commitWriteTransaction(transaction: ReadWriteTransaction<DatabaseCollections>) throws {
         assert(database.isOnWriteQueue(), "Must be called from write queue")
 
         localSnapshot += 1
@@ -355,10 +355,10 @@ public final class Connection {
             }
         }
     }
+}
 
-    private enum ConnectionState {
-        case Inactive
-        case ActiveReadTransaction
-        case ActiveReadWriteTransaction
-    }
+private enum ConnectionState {
+    case Inactive
+    case ActiveReadTransaction
+    case ActiveReadWriteTransaction
 }

--- a/Turf/Core/Database.swift
+++ b/Turf/Core/Database.swift
@@ -2,12 +2,12 @@ import Foundation
 
 private let databaseWriteQueueKey = "databaseWriteQueueKey".UTF8String
 
+public let CollectionChangedNotification = "TurfCollectionChanged"
+public let CollectionChangedNotificationChangeSetKey = "ChangeSet"
+
+
 public final class Database<DatabaseCollections: CollectionsContainer> {
     // MARK: Public properties
-
-    //TODO static
-    public let CollectionChangedNotification = "TurfCollectionChanged"
-    public let CollectionChangedNotificationChangeSetKey = "ChangeSet"
 
     /// Database file url
     public let url: NSURL

--- a/Turf/Core/Database.swift
+++ b/Turf/Core/Database.swift
@@ -11,6 +11,7 @@ public final class Database<DatabaseCollections: CollectionsContainer> {
 
     /// Database file url
     public let url: NSURL
+    public let collections: DatabaseCollections
 
     // MARK: Internal properties
 
@@ -19,7 +20,6 @@ public final class Database<DatabaseCollections: CollectionsContainer> {
 
     // MARK: Private properties
 
-    private let collections: DatabaseCollections
     private var registeredCollectionNames: [String]
     private var connections: [Int: WeakBox<Connection<DatabaseCollections>>]
     private var observingConnections: [Int: WeakBox<ObservingConnection<DatabaseCollections>>]
@@ -264,7 +264,7 @@ public final class Database<DatabaseCollections: CollectionsContainer> {
         let connection = try newConnection()
         try connection.sqlite.setSnapshot(0)
 
-        try connection.readWriteTransaction { transaction in
+        try connection.readWriteTransaction { transaction, _ in
             try collections.setUpCollections(transaction: transaction)
         }
     }

--- a/Turf/Core/Database.swift
+++ b/Turf/Core/Database.swift
@@ -2,11 +2,12 @@ import Foundation
 
 private let databaseWriteQueueKey = "databaseWriteQueueKey".UTF8String
 
-public final class Database {
+public final class Database<DatabaseCollections: CollectionsContainer> {
     // MARK: Public properties
 
-    public static let CollectionChangedNotification = "TurfCollectionChanged"
-    public static let CollectionChangedNotificationChangeSetKey = "ChangeSet"
+    //TODO static
+    public let CollectionChangedNotification = "TurfCollectionChanged"
+    public let CollectionChangedNotificationChangeSetKey = "ChangeSet"
 
     /// Database file url
     public let url: NSURL
@@ -18,10 +19,10 @@ public final class Database {
 
     // MARK: Private properties
 
-    private let collections: CollectionsContainer
+    private let collections: DatabaseCollections
     private var registeredCollectionNames: [String]
-    private var connections: [Int: WeakBox<Connection>]
-    private var observingConnections: [Int: WeakBox<ObservingConnection>]
+    private var connections: [Int: WeakBox<Connection<DatabaseCollections>>]
+    private var observingConnections: [Int: WeakBox<ObservingConnection<DatabaseCollections>>]
     private var lastConnectionId: Int
     private var cacheUpdatesBySnapshot: [UInt64: [String: TypeErasedCacheUpdates]]
     private var minCacheUpdatesSnapshot: UInt64
@@ -40,7 +41,7 @@ public final class Database {
     - parameter collections: Container of collections associated with this database
      - throws: Any error thrown during `collections.setUpCollections(transaction:)` or one of `SQLiteError.FailedToOpenDatabase` or `SQLiteError.Error(code, reason)` if the database failed to open.
     */
-    public convenience init(path: String, collections: CollectionsContainer) throws {
+    public convenience init(path: String, collections: DatabaseCollections) throws {
         try self.init(url: NSURL(string: path)!, collections: collections)
     }
 
@@ -50,7 +51,7 @@ public final class Database {
      - parameter collections: Container of collections associated with this database
      - throws: Any error thrown during `collections.setUpCollections(transaction:)` or one of `SQLiteError.FailedToOpenDatabase` or `SQLiteError.Error(code, reason)` if the database failed to open.
      */
-    public init(url: NSURL, collections: CollectionsContainer) throws {
+    public init(url: NSURL, collections: DatabaseCollections) throws {
         self.url = url
         self.collections = collections
         self.extensions = [:]
@@ -86,7 +87,7 @@ public final class Database {
      - returns: A new sqlite database connection
      - throws: `SQLiteError.FailedToOpenDatabase` or `SQLiteError.Error(code, reason)`
     */
-    public func newConnection() throws -> Connection {
+    public func newConnection() throws -> Connection<DatabaseCollections> {
         defer { OSSpinLockUnlock(&connectionManipulationLock) }
 
         // Since `Connection(...)` can throw, it will dealloc immediately triggering a `deinit`
@@ -106,13 +107,13 @@ public final class Database {
         return connection
     }
 
-    public func newObservingConnection(shouldAdvanceWhenDatabaseChanges shouldAdvanceWhenDatabaseChanges: () -> Bool = { return true }) throws -> ObservingConnection {
+    public func newObservingConnection(shouldAdvanceWhenDatabaseChanges shouldAdvanceWhenDatabaseChanges: () -> Bool = { return true }) throws -> ObservingConnection<DatabaseCollections> {
         let connection = try newConnection()
 
         defer { OSSpinLockUnlock(&connectionManipulationLock) }
         OSSpinLockLock(&connectionManipulationLock)
 
-        let observingConnection = ObservingConnection(
+        let observingConnection = ObservingConnection<DatabaseCollections>(
             connection: connection, shouldAdvanceWhenDatabaseChanges: shouldAdvanceWhenDatabaseChanges)
 
         observingConnections[connection.id] = WeakBox(value: observingConnection)
@@ -132,7 +133,7 @@ public final class Database {
              - Downside is some wasted CPU cycles, but you should not be creating/destroying many connections anyway.
      - parameter connection: A uniquely named database collection to register.
      */
-    func removeConnection(connection: Connection) {
+    func removeConnection(connection: Connection<DatabaseCollections>) {
         precondition(connection.isClosed, "Connection must be closed before removing")
 
         defer { OSSpinLockUnlock(&connectionManipulationLock) }
@@ -259,7 +260,7 @@ public final class Database {
 
     // MARK: Private methods
 
-    private func setUpCollections(collections: CollectionsContainer) throws {
+    private func setUpCollections(collections: DatabaseCollections) throws {
         let connection = try newConnection()
         try connection.sqlite.setSnapshot(0)
 

--- a/Turf/Core/ObservingConnection.swift
+++ b/Turf/Core/ObservingConnection.swift
@@ -41,7 +41,7 @@ public final class ObservingConnection<DatabaseCollections: CollectionsContainer
             guard let strongSelf = self else { return }
 
             let observableCollection = strongSelf.observableCollections[collection.name] as! ObservableCollection<TCollection, DatabaseCollections>
-            let readCollection = collection.readOnly(transaction)
+            let readCollection = transaction.readOnly(collection)
             observableCollection.processCollectionChanges(readCollection, changeSet: changeSet)
         }
 

--- a/Turf/Core/ReadTransaction.swift
+++ b/Turf/Core/ReadTransaction.swift
@@ -4,6 +4,9 @@ public class ReadTransaction<DatabaseCollections: CollectionsContainer> {
     /// Reference to parent connection
     public unowned let connection: Connection<DatabaseCollections>
 
+    /// Available collections associated with this database transaction
+    public var collections: DatabaseCollections { return connection.database.collections }
+
     // MARK: Internal properties
 
     // MARK: Private properties

--- a/Turf/Core/ReadTransaction.swift
+++ b/Turf/Core/ReadTransaction.swift
@@ -1,8 +1,8 @@
-public class ReadTransaction {
+public class ReadTransaction<DatabaseCollections: CollectionsContainer> {
     // MARK: Public properties
 
     /// Reference to parent connection
-    public unowned let connection: Connection
+    public unowned let connection: Connection<DatabaseCollections>
 
     // MARK: Internal properties
 
@@ -10,7 +10,7 @@ public class ReadTransaction {
 
     // MARK: Object life cycle
 
-    internal init(connection: Connection) {
+    internal init(connection: Connection<DatabaseCollections>) {
         self.connection = connection
     }
 
@@ -26,7 +26,7 @@ public class ReadTransaction {
      - returns: Read only view of `collection`
      - parameter collection: The Collection we want a readonly view of
      */
-    public func readOnly<TCollection: Collection>(collection: TCollection) -> ReadCollection<TCollection> {
+    public func readOnly<TCollection: Collection>(collection: TCollection) -> ReadCollection<TCollection, DatabaseCollections> {
         return ReadCollection(collection: collection, transaction: self)
     }
 

--- a/Turf/Core/ReadWriteTransaction.swift
+++ b/Turf/Core/ReadWriteTransaction.swift
@@ -1,4 +1,4 @@
-public final class ReadWriteTransaction: ReadTransaction {
+public final class ReadWriteTransaction<DatabaseCollections: CollectionsContainer>: ReadTransaction<DatabaseCollections> {
     // MARK: Public properties
 
     // MARK: Internal properties
@@ -9,7 +9,7 @@ public final class ReadWriteTransaction: ReadTransaction {
 
     // MARK: Object life cycle
 
-    internal override init(connection: Connection) {
+    internal override init(connection: Connection<DatabaseCollections>) {
         self.shouldRollback = false
         super.init(connection: connection)
     }
@@ -32,7 +32,7 @@ public final class ReadWriteTransaction: ReadTransaction {
      - returns: Read-write view of `collection`
      - parameter collection: The Collection we want a read-write view of
     */
-    public func readWrite<TCollection: Collection>(collection: TCollection) -> ReadWriteCollection<TCollection> {
+    public func readWrite<TCollection: Collection>(collection: TCollection) -> ReadWriteCollection<TCollection, DatabaseCollections> {
         //TODO Cache 
         return ReadWriteCollection(collection: collection, transaction: self)
     }

--- a/Turf/Core/ReadWriteTransaction.swift
+++ b/Turf/Core/ReadWriteTransaction.swift
@@ -1,4 +1,4 @@
-public final class ReadWriteTransaction<DatabaseCollections: CollectionsContainer>: ReadTransaction<DatabaseCollections> {
+public final class ReadWriteTransaction<Collections: CollectionsContainer>: ReadTransaction<Collections> {
     // MARK: Public properties
 
     // MARK: Internal properties
@@ -9,7 +9,7 @@ public final class ReadWriteTransaction<DatabaseCollections: CollectionsContaine
 
     // MARK: Object life cycle
 
-    internal override init(connection: Connection<DatabaseCollections>) {
+    internal override init(connection: Connection<Collections>) {
         self.shouldRollback = false
         super.init(connection: connection)
     }
@@ -32,7 +32,7 @@ public final class ReadWriteTransaction<DatabaseCollections: CollectionsContaine
      - returns: Read-write view of `collection`
      - parameter collection: The Collection we want a read-write view of
     */
-    public func readWrite<TCollection: Collection>(collection: TCollection) -> ReadWriteCollection<TCollection, DatabaseCollections> {
+    public func readWrite<TCollection: Collection>(collection: TCollection) -> ReadWriteCollection<TCollection, Collections> {
         //TODO Cache 
         return ReadWriteCollection(collection: collection, transaction: self)
     }
@@ -55,6 +55,8 @@ public final class ReadWriteTransaction<DatabaseCollections: CollectionsContaine
      - parameter ext: An installable extension
      */
     public func registerExtension<Ext: Extension>(ext: Ext) throws {
-        try connection.registerExtension(ext, onTransaction: self)
+        //FIXME segfault
+        let localConnection: Connection<Collections> = connection
+        try localConnection.registerExtension(ext, onTransaction: self)
     }
 }

--- a/Turf/Extensions/Protocols/Extension.swift
+++ b/Turf/Extensions/Protocols/Extension.swift
@@ -20,7 +20,7 @@ public protocol Extension {
      - parameter connection: Turf.Connection that can be passed to the extension's connection if required
      - returns: An extension's connection
      */
-    func newConnection(connection: Connection) -> ExtensionConnection
+    func newConnection<DatabaseCollections: CollectionsContainer>(connection: Connection<DatabaseCollections>) -> ExtensionConnection
 
     /**
      Called when the extension is registered.
@@ -28,7 +28,7 @@ public protocol Extension {
      - warning: Do no begin/commit/rollback any transactions - a transaction has already been opened for this db and will be commited at a point after `install(db:)`
      - parameter db: sqlite3* pointer which can be used to modify the database.
      */
-    func install(transaction: ReadWriteTransaction<DatabaseCollections>, db: SQLitePtr, existingInstallationDetails: ExistingExtensionInstallation?) throws
+    func install<DatabaseCollections: CollectionsContainer>(transaction: ReadWriteTransaction<DatabaseCollections>, db: SQLitePtr, existingInstallationDetails: ExistingExtensionInstallation?) throws
 
     /**
      Called when the extension is unregistered.

--- a/Turf/Extensions/Protocols/Extension.swift
+++ b/Turf/Extensions/Protocols/Extension.swift
@@ -4,6 +4,7 @@ public typealias SQLitePtr = COpaquePointer
  Defines a basic database extension.
  */
 public protocol Extension {
+
     /// Each exension instance must have a unique name
     var uniqueName: String { get }
 
@@ -27,7 +28,7 @@ public protocol Extension {
      - warning: Do no begin/commit/rollback any transactions - a transaction has already been opened for this db and will be commited at a point after `install(db:)`
      - parameter db: sqlite3* pointer which can be used to modify the database.
      */
-    func install(transaction: ReadWriteTransaction, db: SQLitePtr, existingInstallationDetails: ExistingExtensionInstallation?) throws
+    func install(transaction: ReadWriteTransaction<DatabaseCollections>, db: SQLitePtr, existingInstallationDetails: ExistingExtensionInstallation?) throws
 
     /**
      Called when the extension is unregistered.

--- a/Turf/Extensions/Protocols/ExtensionConnection.swift
+++ b/Turf/Extensions/Protocols/ExtensionConnection.swift
@@ -13,5 +13,5 @@ public protocol ExtensionConnection {
      - parameter transaction: Read-write transaction
      - returns: An extension's write transaction
      */
-    func writeTransaction(transaction: ReadWriteTransaction) -> ExtensionWriteTransaction
+    func writeTransaction<DatabaseCollections: CollectionsContainer>(transaction: ReadWriteTransaction<DatabaseCollections>) -> ExtensionWriteTransaction
 }

--- a/Turf/Extensions/SecondaryIndex/Internals/SecondaryIndexConnection.swift
+++ b/Turf/Extensions/SecondaryIndex/Internals/SecondaryIndexConnection.swift
@@ -10,13 +10,10 @@ internal class SecondaryIndexConnection<TCollection: Collection, Properties: Ind
 
     // MARK: Private properties
 
-    private unowned let connection: Connection
-
     // MARK: Object lifecycle
 
-    internal init(index: SecondaryIndex<TCollection, Properties>, connection: Connection) {
+    internal init(index: SecondaryIndex<TCollection, Properties>) {
         self.index = index
-        self.connection = connection
     }
 
     deinit {
@@ -28,8 +25,8 @@ internal class SecondaryIndexConnection<TCollection: Collection, Properties: Ind
 
     // MARK: Internal methods
 
-    func writeTransaction(transaction: ReadWriteTransaction) -> ExtensionWriteTransaction {
-        return SecondaryIndexWriteTransaction(connection: self, transaction: transaction)
+    func writeTransaction<DatabaseCollections: CollectionsContainer>(transaction: ReadWriteTransaction<DatabaseCollections>) -> ExtensionWriteTransaction {
+        return SecondaryIndexWriteTransaction(connection: self)
     }
 
     func prepare(db: SQLitePtr) throws {

--- a/Turf/Extensions/SecondaryIndex/Internals/SecondaryIndexWriteTransaction.swift
+++ b/Turf/Extensions/SecondaryIndex/Internals/SecondaryIndexWriteTransaction.swift
@@ -2,13 +2,11 @@ internal class SecondaryIndexWriteTransaction<IndexedCollection: Collection, Pro
     // MARK: Private properties
 
     private unowned let connection: SecondaryIndexConnection<IndexedCollection, Properties>
-    private unowned let transaction: ReadWriteTransaction
 
     // MARK: Object lifecycle
 
-    internal init(connection: SecondaryIndexConnection<IndexedCollection, Properties>, transaction: ReadWriteTransaction) {
+    internal init(connection: SecondaryIndexConnection<IndexedCollection, Properties>) {
         self.connection = connection
-        self.transaction = transaction
     }
 
     // MARK: Internal methods

--- a/Turf/Extensions/SecondaryIndex/ObservableCollection+IndexedCollection.swift
+++ b/Turf/Extensions/SecondaryIndex/ObservableCollection+IndexedCollection.swift
@@ -12,8 +12,8 @@ extension ObservableCollection where TCollection: IndexedCollection {
      - parameter thread: Thread to execute the prefilter and potential query on.
      - parameter prefilterChangeSet: Executed before querying the collection to determine if the query is required.
      */
-    public func valuesWhere(clause: WhereClause, thread: CallbackThread = .CallingThread, prefilterChangeSet: Prefilter = nil) -> CollectionTypeObserver<[TCollection.Value]> {
-        let queryResultsObserver = CollectionTypeObserver<[TCollection.Value]>(initalValue: [])
+    public func valuesWhere(clause: WhereClause, thread: CallbackThread = .CallingThread, prefilterChangeSet: Prefilter = nil) -> CollectionTypeObserver<[TCollection.Value], Collections> {
+        let queryResultsObserver = CollectionTypeObserver<[TCollection.Value], Collections>(initalValue: [])
 
         let disposable =
             didChange(thread) { (collection, changeSet) in
@@ -44,8 +44,8 @@ extension ObservableCollection where TCollection: IndexedCollection {
      - parameter thread: Thread to execute the prefilter and potential query on.
      - parameter prefilterChangeSet: Executed before querying the collection to determine if the query is required.
      */
-    public func valuesWhere(preparedQuery: PreparedValuesWhereQuery, thread: CallbackThread = .CallingThread, prefilterChangeSet: Prefilter = nil) -> CollectionTypeObserver<[TCollection.Value]> {
-        let queryResultsObserver = CollectionTypeObserver<[TCollection.Value]>(initalValue: [])
+    public func valuesWhere(preparedQuery: PreparedValuesWhereQuery<Collections>, thread: CallbackThread = .CallingThread, prefilterChangeSet: Prefilter = nil) -> CollectionTypeObserver<[TCollection.Value], Collections> {
+        let queryResultsObserver = CollectionTypeObserver<[TCollection.Value], Collections>(initalValue: [])
 
         let disposable =
             didChange(thread) { (collection, changeSet) in
@@ -76,8 +76,8 @@ extension ObservableCollection where TCollection: IndexedCollection {
      - parameter thread: Thread to execute the prefilter and potential query on.
      - parameter prefilterChangeSet: Executed before querying the collection to determine if the query is required.
      */
-    public func valuesWhere(predicate: String, thread: CallbackThread = .CallingThread, prefilterChangeSet: Prefilter = nil) -> CollectionTypeObserver<[TCollection.Value]> {
-        let queryResultsObserver = CollectionTypeObserver<[TCollection.Value]>(initalValue: [])
+    public func valuesWhere(predicate: String, thread: CallbackThread = .CallingThread, prefilterChangeSet: Prefilter = nil) -> CollectionTypeObserver<[TCollection.Value], Collections> {
+        let queryResultsObserver = CollectionTypeObserver<[TCollection.Value], Collections>(initalValue: [])
 
         let disposable =
             didChange(thread) { (collection, changeSet) in

--- a/Turf/Extensions/SecondaryIndex/PreparedQueries/Connection+PreparedQuery.swift
+++ b/Turf/Extensions/SecondaryIndex/PreparedQueries/Connection+PreparedQuery.swift
@@ -6,7 +6,7 @@ extension Connection {
      - parameter collection: Secondary indexed collection where a matching value will be searched for.
      - parameter valueWhere: Query clause.
      */
-    public func prepareQueryFor<TCollection: IndexedCollection>(collection: TCollection, valueWhere clause: WhereClause) throws -> PreparedValueWhereQuery {
+    public func prepareQueryFor<TCollection: IndexedCollection>(collection: TCollection, valueWhere clause: WhereClause) throws -> PreparedValueWhereQuery<Collections> {
         var stmt: COpaquePointer = nil
 
         let sql = "SELECT targetPrimaryKey FROM \(collection.index.tableName) WHERE \(clause.sql)"
@@ -25,7 +25,7 @@ extension Connection {
      - parameter collection: Secondary indexed collection where matching values will be searched for.
      - parameter valuesWhere: Query clause.
      */
-    public func prepareQueryFor<TCollection: IndexedCollection>(collection: TCollection, valuesWhere clause: WhereClause) throws -> PreparedValuesWhereQuery {
+    public func prepareQueryFor<TCollection: IndexedCollection>(collection: TCollection, valuesWhere clause: WhereClause) throws -> PreparedValuesWhereQuery<Collections> {
         var stmt: COpaquePointer = nil
 
         let sql = "SELECT targetPrimaryKey FROM \(collection.index.tableName) WHERE \(clause.sql)"
@@ -44,7 +44,7 @@ extension Connection {
      - parameter collection: Secondary indexed collection where matching values will be counted.
      - parameter countWhere: Query clause.
      */
-    public func prepareQueryFor<TCollection: IndexedCollection>(collection: TCollection, countWhere clause: WhereClause) throws -> PreparedCountWhereQuery {
+    public func prepareQueryFor<TCollection: IndexedCollection>(collection: TCollection, countWhere clause: WhereClause) throws -> PreparedCountWhereQuery<Collections> {
         var stmt: COpaquePointer = nil
 
         let sql = "SELECT COUNT(targetPrimaryKey) FROM \(collection.index.tableName) WHERE \(clause.sql)"

--- a/Turf/Extensions/SecondaryIndex/PreparedQueries/ObservingConnection+PreparedQuery.swift
+++ b/Turf/Extensions/SecondaryIndex/PreparedQueries/ObservingConnection+PreparedQuery.swift
@@ -6,7 +6,7 @@ extension ObservingConnection {
      - parameter collection: Secondary indexed collection where a matching value will be searched for.
      - parameter valueWhere: Query clause.
      */
-    public func prepareQueryFor<TCollection: IndexedCollection>(collection: TCollection, valueWhere clause: WhereClause) throws -> PreparedValueWhereQuery {
+    public func prepareQueryFor<TCollection: IndexedCollection>(collection: TCollection, valueWhere clause: WhereClause) throws -> PreparedValueWhereQuery<Collections> {
         return try connection.prepareQueryFor(collection, valueWhere: clause)
     }
 
@@ -17,7 +17,7 @@ extension ObservingConnection {
      - parameter collection: Secondary indexed collection where matching values will be searched for.
      - parameter valuesWhere: Query clause.
      */
-    public func prepareQueryFor<TCollection: IndexedCollection>(collection: TCollection, valuesWhere clause: WhereClause) throws -> PreparedValuesWhereQuery {
+    public func prepareQueryFor<TCollection: IndexedCollection>(collection: TCollection, valuesWhere clause: WhereClause) throws -> PreparedValuesWhereQuery<Collections> {
         return try connection.prepareQueryFor(collection, valuesWhere: clause)
     }
 
@@ -28,7 +28,7 @@ extension ObservingConnection {
      - parameter collection: Secondary indexed collection where matching values will be counted.
      - parameter countWhere: Query clause.
      */
-    public func prepareQueryFor<TCollection: IndexedCollection>(collection: TCollection, countWhere clause: WhereClause) throws -> PreparedCountWhereQuery {
+    public func prepareQueryFor<TCollection: IndexedCollection>(collection: TCollection, countWhere clause: WhereClause) throws -> PreparedCountWhereQuery<Collections> {
         return try connection.prepareQueryFor(collection, countWhere: clause)
     }
 }

--- a/Turf/Extensions/SecondaryIndex/PreparedQueries/PreparedQuery.swift
+++ b/Turf/Extensions/SecondaryIndex/PreparedQueries/PreparedQuery.swift
@@ -1,4 +1,4 @@
-public class PreparedQuery {
+public class PreparedQuery<Collections: CollectionsContainer> {
     // MARK: Public properties
 
     public let clause: WhereClause
@@ -6,11 +6,11 @@ public class PreparedQuery {
     // MARK: Internal properties
 
     let stmt: COpaquePointer
-    weak var connection: Connection?
+    weak var connection: Connection<Collections>?
 
     // MARK: Object lifecycle
 
-    init(clause: WhereClause, stmt: COpaquePointer, connection: Connection) {
+    init(clause: WhereClause, stmt: COpaquePointer, connection: Connection<Collections>) {
         self.clause = clause
         self.stmt = stmt
         self.connection = connection
@@ -21,6 +21,20 @@ public class PreparedQuery {
     }
 }
 
-public class PreparedValueWhereQuery: PreparedQuery { }
-public class PreparedValuesWhereQuery: PreparedQuery { }
-public class PreparedCountWhereQuery: PreparedQuery { }
+public class PreparedValueWhereQuery<Collections: CollectionsContainer>: PreparedQuery<Collections> {
+    override init(clause: WhereClause, stmt: COpaquePointer, connection: Connection<Collections>) {
+        super.init(clause: clause, stmt: stmt, connection: connection)
+    }
+}
+
+public class PreparedValuesWhereQuery<Collections: CollectionsContainer>: PreparedQuery<Collections> {
+    override init(clause: WhereClause, stmt: COpaquePointer, connection: Connection<Collections>) {
+        super.init(clause: clause, stmt: stmt, connection: connection)
+    }
+}
+
+public class PreparedCountWhereQuery<Collections: CollectionsContainer>: PreparedQuery<Collections> {
+    override init(clause: WhereClause, stmt: COpaquePointer, connection: Connection<Collections>) {
+        super.init(clause: clause, stmt: stmt, connection: connection)
+    }
+}

--- a/Turf/Extensions/SecondaryIndex/ReadCollection+IndexedCollection.swift
+++ b/Turf/Extensions/SecondaryIndex/ReadCollection+IndexedCollection.swift
@@ -124,7 +124,7 @@ public extension ReadCollection where TCollection: IndexedCollection {
      - parameter predicate: Query on secondary indexed properties
      - returns: Value if there is a match
      */
-    public func findFirstValueWhere(preparedQuery: PreparedValueWhereQuery) -> Value? {
+    public func findFirstValueWhere(preparedQuery: PreparedValueWhereQuery<Collections>) -> Value? {
         precondition(preparedQuery.connection === readTransaction.connection,
                      "Prepared queries must be run on the same connection they were created from")
 
@@ -159,7 +159,7 @@ public extension ReadCollection where TCollection: IndexedCollection {
      - parameter predicate: Query on secondary indexed properties
      - returns: Values that match the predicate
      */
-    public func findValuesWhere(preparedQuery: PreparedValuesWhereQuery) -> [Value] {
+    public func findValuesWhere(preparedQuery: PreparedValuesWhereQuery<Collections>) -> [Value] {
         precondition(preparedQuery.connection === readTransaction.connection,
                      "Prepared queries must be run on the same connection they were created from")
 
@@ -197,7 +197,7 @@ public extension ReadCollection where TCollection: IndexedCollection {
      - parameter predicate: Query on secondary indexed properties
      - returns: Number of values that match the predicate
      */
-    public func countValuesWhere(preparedQuery: PreparedCountWhereQuery) -> Int {
+    public func countValuesWhere(preparedQuery: PreparedCountWhereQuery<Collections>) -> Int {
         precondition(preparedQuery.connection === readTransaction.connection,
                      "Prepared queries must be run on the same connection they were created from")
 
@@ -262,6 +262,8 @@ public extension ReadCollection where TCollection: IndexedCollection {
     // MARK: Private methods
 
     internal func extensionConnection() -> SecondaryIndexConnection<TCollection, TCollection.IndexProperties> {
-        return try! readTransaction.connection.connectionForExtension(collection.index) as! SecondaryIndexConnection<TCollection, TCollection.IndexProperties>
+        //FIXME segfault
+        let connection: Connection<Collections> = readTransaction.connection
+        return try! connection.connectionForExtension(collection.index) as! SecondaryIndexConnection<TCollection, TCollection.IndexProperties>
     }
 }

--- a/Turf/Extensions/SecondaryIndex/SecondaryIndex.swift
+++ b/Turf/Extensions/SecondaryIndex/SecondaryIndex.swift
@@ -43,11 +43,11 @@ public class SecondaryIndex<TCollection: Collection, Properties: IndexedProperti
         self.properties = properties
     }
 
-    public func newConnection(connection: Connection) -> ExtensionConnection {
-        return SecondaryIndexConnection(index: self, connection: connection)
+    public func newConnection<DatabaseCollections: CollectionsContainer>(connection: Connection<DatabaseCollections>) -> ExtensionConnection {
+        return SecondaryIndexConnection(index: self)
     }
 
-    public func install(transaction: ReadWriteTransaction, db: SQLitePtr, existingInstallationDetails: ExistingExtensionInstallation?) throws {
+    public func install<DatabaseCollections: CollectionsContainer>(transaction: ReadWriteTransaction<DatabaseCollections>, db: SQLitePtr, existingInstallationDetails: ExistingExtensionInstallation?) throws {
         let requiresRepopulation = try handleExistingInstallation(existingInstallationDetails, db: db)
 
         let sql = createTableSql()
@@ -73,7 +73,7 @@ public class SecondaryIndex<TCollection: Collection, Properties: IndexedProperti
 
     // MARK: Private methods
 
-    private func repopulate(transaction: ReadWriteTransaction, collection: TCollection) throws {
+    private func repopulate<DatabaseCollections: CollectionsContainer>(transaction: ReadWriteTransaction<DatabaseCollections>, collection: TCollection) throws {
         let readOnlyCollection = transaction.readOnly(collection)
         let extensionTransaction = newConnection(transaction.connection).writeTransaction(transaction)
 

--- a/Turf/Observable/CollectionTypeObserver.swift
+++ b/Turf/Observable/CollectionTypeObserver.swift
@@ -1,9 +1,9 @@
-public class CollectionTypeObserver<Collection: CollectionType where Collection.Index : BidirectionalIndexType>: ObserverOf<Collection> {
+public class CollectionTypeObserver<Collection: CollectionType, DatabaseCollections: CollectionsContainer where Collection.Index : BidirectionalIndexType>: ObserverOf<Collection, DatabaseCollections> {
 
     // MARK: Public properties
 
-    public let first: ObserverOf<Collection.Generator.Element?>
-    public let last: ObserverOf<Collection.Generator.Element?>
+    public let first: ObserverOf<Collection.Generator.Element?, DatabaseCollections>
+    public let last: ObserverOf<Collection.Generator.Element?, DatabaseCollections>
 
     // MARK: Object lifecycle
 
@@ -26,8 +26,8 @@ public class CollectionTypeObserver<Collection: CollectionType where Collection.
      - note:
         Thread safe.
      */
-    public func observeIndex(index: Collection.Index) -> ObserverOf<Collection.Generator.Element?> {
-        let observer = ObserverOf<Collection.Generator.Element?>(initalValue: nil)
+    public func observeIndex(index: Collection.Index) -> ObserverOf<Collection.Generator.Element?, DatabaseCollections> {
+        let observer = ObserverOf<Collection.Generator.Element?, DatabaseCollections>(initalValue: nil)
 
         let disposeable =
         didChange { (newCollection, transaction) in
@@ -52,8 +52,8 @@ public extension CollectionTypeObserver where Collection: CollectionType, Collec
      - note:
         Thread safe.
      */
-    public func observeIndex(index: Collection.Index) -> ObserverOf<Collection.Generator.Element?> {
-        let observer = ObserverOf<Collection.Generator.Element?>(initalValue: nil)
+    public func observeIndex(index: Collection.Index) -> ObserverOf<Collection.Generator.Element?, DatabaseCollections> {
+        let observer = ObserverOf<Collection.Generator.Element?, DatabaseCollections>(initalValue: nil)
 
         let disposeable =
         didChange { (newCollection, transaction) in

--- a/Turf/Observable/ObservableCollection.swift
+++ b/Turf/Observable/ObservableCollection.swift
@@ -1,8 +1,8 @@
-public class ObservableCollection<TCollection: Collection, DatabaseCollections: CollectionsContainer>: TypedObservable, TypeErasedObservableCollection {
-    public typealias Callback = (ReadCollection<TCollection, DatabaseCollections>?, ChangeSet<String>) -> Void
+public class ObservableCollection<TCollection: Collection, Collections: CollectionsContainer>: TypedObservable, TypeErasedObservableCollection {
+    public typealias Callback = (ReadCollection<TCollection, Collections>?, ChangeSet<String>) -> Void
 
     // MARK: Public properties
-    public private(set) var value: ReadCollection<TCollection, DatabaseCollections>?
+    public private(set) var value: ReadCollection<TCollection, Collections>?
 
     public let disposeBag: DisposeBag
 
@@ -58,7 +58,7 @@ public class ObservableCollection<TCollection: Collection, DatabaseCollections: 
      - parameter changeSet: The changes applied to bring `collection` to its current point.
      - parameter cacheUpdates: Updates made to the cache to bring `collection` to its current point.
      */
-    func processCollectionChanges(collection: ReadCollection<TCollection, DatabaseCollections>, changeSet: ChangeSet<String>) {
+    func processCollectionChanges(collection: ReadCollection<TCollection, Collections>, changeSet: ChangeSet<String>) {
         defer { OSSpinLockUnlock(&lock) }
         OSSpinLockLock(&lock)
 

--- a/Turf/Observable/ObservableCollection.swift
+++ b/Turf/Observable/ObservableCollection.swift
@@ -1,8 +1,8 @@
-public class ObservableCollection<TCollection: Collection>: TypedObservable, TypeErasedObservableCollection {
-    public typealias Callback = (ReadCollection<TCollection>?, ChangeSet<String>) -> Void
+public class ObservableCollection<TCollection: Collection, DatabaseCollections: CollectionsContainer>: TypedObservable, TypeErasedObservableCollection {
+    public typealias Callback = (ReadCollection<TCollection, DatabaseCollections>?, ChangeSet<String>) -> Void
 
     // MARK: Public properties
-    public private(set) var value: ReadCollection<TCollection>?
+    public private(set) var value: ReadCollection<TCollection, DatabaseCollections>?
 
     public let disposeBag: DisposeBag
 
@@ -58,7 +58,7 @@ public class ObservableCollection<TCollection: Collection>: TypedObservable, Typ
      - parameter changeSet: The changes applied to bring `collection` to its current point.
      - parameter cacheUpdates: Updates made to the cache to bring `collection` to its current point.
      */
-    func processCollectionChanges(collection: ReadCollection<TCollection>, changeSet: ChangeSet<String>) {
+    func processCollectionChanges(collection: ReadCollection<TCollection, DatabaseCollections>, changeSet: ChangeSet<String>) {
         defer { OSSpinLockUnlock(&lock) }
         OSSpinLockLock(&lock)
 

--- a/Turf/Observable/ObserverOf.swift
+++ b/Turf/Observable/ObserverOf.swift
@@ -1,7 +1,7 @@
-public class ObserverOf<T>: TypedObservable {
+public class ObserverOf<T, DatabaseCollections: CollectionsContainer>: TypedObservable {
     // MARK: Public properties
     public typealias Value = T
-    public typealias Callback = (T, ReadTransaction?) -> Void
+    public typealias Callback = (T, ReadTransaction<DatabaseCollections>?) -> Void
 
     public private(set) var value: T
 
@@ -31,7 +31,7 @@ public class ObserverOf<T>: TypedObservable {
      - note:
         Thread safe.
      */
-    public func didChange(thread: CallbackThread = .CallingThread, callback: (T, ReadTransaction?) -> Void) -> Disposable {
+    public func didChange(thread: CallbackThread = .CallingThread, callback: (T, ReadTransaction<DatabaseCollections>?) -> Void) -> Disposable {
         OSSpinLockLock(&lock)
 
         let token = nextObserverToken
@@ -53,7 +53,7 @@ public class ObserverOf<T>: TypedObservable {
      - note:
         Thread safe
      */
-    public func setValue(value: T, fromTransaction transaction: ReadTransaction?) {
+    public func setValue(value: T, fromTransaction transaction: ReadTransaction<DatabaseCollections>?) {
         defer { OSSpinLockUnlock(&lock) }
         OSSpinLockLock(&lock)
 
@@ -63,7 +63,7 @@ public class ObserverOf<T>: TypedObservable {
 
     // MARK: Private methods
 
-    private func onValueSet(newValue: T, transaction: ReadTransaction?) {
+    private func onValueSet(newValue: T, transaction: ReadTransaction<DatabaseCollections>?) {
         for (_, observer) in observers {
             observer.thread.dispatchSynchronously {
                 observer.callback(newValue, transaction)

--- a/TurfRegressionTests/BasicRegressionTests.swift
+++ b/TurfRegressionTests/BasicRegressionTests.swift
@@ -8,9 +8,9 @@ class BasicRegressionTests: QuickSpec {
             var tester: TestDatabase!
             beforeEach {
                 tester = try! TestDatabase(databasePath: "BasicRegressionTests.sqlite")
-                try! tester.connection1.readWriteTransaction { transaction in
-                    transaction.readWrite(tester.collections.cars).removeAllValues()
-                    transaction.readWrite(tester.collections.wheels).removeAllValues()
+                try! tester.connection1.readWriteTransaction { transaction, collections in
+                    transaction.readWrite(collections.cars).removeAllValues()
+                    transaction.readWrite(collections.wheels).removeAllValues()
                 }
             }
 
@@ -23,14 +23,14 @@ class BasicRegressionTests: QuickSpec {
                         it("successfully writes a model and can read it back") {
                             let expectedCar = CarModel(uuid: "test_1", manufacturer: "McLaren", name: "P1", doors: 2)
 
-                            try! tester.connection1.readWriteTransaction { transaction in
-                                let collection = transaction.readWrite(tester.collections.cars)
+                            try! tester.connection1.readWriteTransaction { transaction, collections in
+                                let collection = transaction.readWrite(collections.cars)
                                 collection.setValue(expectedCar, forKey: expectedCar.uuid)
                             }
 
                             var fetchedCar: CarModel?
-                            try! tester.connection1.readWriteTransaction { transaction in
-                                let collection = transaction.readWrite(tester.collections.cars)
+                            try! tester.connection1.readWriteTransaction { transaction, collections in
+                                let collection = transaction.readWrite(collections.cars)
                                 fetchedCar = collection.valueForKey("test_1")
                             }
 
@@ -46,14 +46,14 @@ class BasicRegressionTests: QuickSpec {
                             it("successfully writes a model and can read it back") {
                                 let expectedCar = CarModel(uuid: "test_1", manufacturer: "McLaren", name: "P1", doors: 2)
 
-                                try! tester.connection1.readWriteTransaction { transaction in
-                                    let collection = transaction.readWrite(tester.collections.cars)
+                                try! tester.connection1.readWriteTransaction { transaction, collections in
+                                    let collection = transaction.readWrite(collections.cars)
                                     collection.setValue(expectedCar, forKey: expectedCar.uuid)
                                 }
 
                                 var fetchedCar: CarModel?
-                                try! tester.connection1.readWriteTransaction { transaction in
-                                    let collection = transaction.readOnly(tester.collections.cars)
+                                try! tester.connection1.readWriteTransaction { transaction, collections in
+                                    let collection = transaction.readOnly(collections.cars)
                                     fetchedCar = collection.valueForKey("test_1")
                                 }
 
@@ -68,14 +68,14 @@ class BasicRegressionTests: QuickSpec {
                             it("successfully writes a model and can read it back") {
                                 let expectedCar = CarModel(uuid: "test_1", manufacturer: "McLaren", name: "P1", doors: 2)
 
-                                try! tester.connection1.readWriteTransaction { transaction in
-                                    let collection = transaction.readWrite(tester.collections.cars)
+                                try! tester.connection1.readWriteTransaction { transaction, collections in
+                                    let collection = transaction.readWrite(collections.cars)
                                     collection.setValue(expectedCar, forKey: expectedCar.uuid)
                                 }
 
                                 var fetchedCar: CarModel?
-                                try! tester.connection1.readTransaction { transaction in
-                                    let collection = transaction.readOnly(tester.collections.cars)
+                                try! tester.connection1.readTransaction { transaction, collections in
+                                    let collection = transaction.readOnly(collections.cars)
                                     fetchedCar = collection.valueForKey("test_1")
                                 }
 
@@ -96,14 +96,14 @@ class BasicRegressionTests: QuickSpec {
                         it("successfully writes a model and can read it back") {
                             let expectedCar = CarModel(uuid: "test_1", manufacturer: "McLaren", name: "P1", doors: 2)
 
-                            try! tester.connection1.readWriteTransaction { transaction in
-                                let collection = transaction.readWrite(tester.collections.cars)
+                            try! tester.connection1.readWriteTransaction { transaction, collections in
+                                let collection = transaction.readWrite(collections.cars)
                                 collection.setValue(expectedCar, forKey: expectedCar.uuid)
                             }
 
                             var fetchedCar: CarModel?
-                            try! tester.connection2.readWriteTransaction { transaction in
-                                let collection = transaction.readWrite(tester.collections.cars)
+                            try! tester.connection2.readWriteTransaction { transaction, collections in
+                                let collection = transaction.readWrite(collections.cars)
                                 fetchedCar = collection.valueForKey("test_1")
                             }
 
@@ -119,14 +119,14 @@ class BasicRegressionTests: QuickSpec {
                             it("successfully writes a model and can read it back") {
                                 let expectedCar = CarModel(uuid: "test_1", manufacturer: "McLaren", name: "P1", doors: 2)
 
-                                try! tester.connection1.readWriteTransaction { transaction in
-                                    let collection = transaction.readWrite(tester.collections.cars)
+                                try! tester.connection1.readWriteTransaction { transaction, collections in
+                                    let collection = transaction.readWrite(collections.cars)
                                     collection.setValue(expectedCar, forKey: expectedCar.uuid)
                                 }
 
                                 var fetchedCar: CarModel?
-                                try! tester.connection2.readWriteTransaction { transaction in
-                                    let collection = transaction.readOnly(tester.collections.cars)
+                                try! tester.connection2.readWriteTransaction { transaction, collections in
+                                    let collection = transaction.readOnly(collections.cars)
                                     fetchedCar = collection.valueForKey("test_1")
                                 }
 
@@ -141,14 +141,14 @@ class BasicRegressionTests: QuickSpec {
                             it("successfully writes a model and can read it back") {
                                 let expectedCar = CarModel(uuid: "test_1", manufacturer: "McLaren", name: "P1", doors: 2)
 
-                                try! tester.connection1.readWriteTransaction { transaction in
-                                    let collection = transaction.readWrite(tester.collections.cars)
+                                try! tester.connection1.readWriteTransaction { transaction, collections in
+                                    let collection = transaction.readWrite(collections.cars)
                                     collection.setValue(expectedCar, forKey: expectedCar.uuid)
                                 }
 
                                 var fetchedCar: CarModel?
-                                try! tester.connection2.readTransaction { transaction in
-                                    let collection = transaction.readOnly(tester.collections.cars)
+                                try! tester.connection2.readTransaction { transaction, collections in
+                                    let collection = transaction.readOnly(collections.cars)
                                     fetchedCar = collection.valueForKey("test_1")
                                 }
 
@@ -171,15 +171,15 @@ class BasicRegressionTests: QuickSpec {
                         it("successfully writes a model and can read it back") {
                             let expectedWheel = WheelModel(uuid: "test_1", manufacturer: "Pirelli", size: 18.0)
 
-                            try! tester.connection1.readWriteTransaction { transaction in
-                                let collection = transaction.readWrite(tester.collections.wheels)
+                            try! tester.connection1.readWriteTransaction { transaction, collections in
+                                let collection = transaction.readWrite(collections.wheels)
                                 collection.setValue(expectedWheel, forKey: expectedWheel.uuid)
                             }
 
                             var fetchedWheel: WheelModel?
 
-                            try! tester.connection1.readWriteTransaction { transaction in
-                                let collection = transaction.readWrite(tester.collections.wheels)
+                            try! tester.connection1.readWriteTransaction { transaction, collections in
+                                let collection = transaction.readWrite(collections.wheels)
                                 fetchedWheel = collection.valueForKey("test_1")
                             }
 
@@ -194,15 +194,15 @@ class BasicRegressionTests: QuickSpec {
                         it("successfully writes a model and can read it back") {
                             let expectedWheel = WheelModel(uuid: "test_1", manufacturer: "Pirelli", size: 18.0)
 
-                            try! tester.connection1.readWriteTransaction { transaction in
-                                let collection = transaction.readWrite(tester.collections.wheels)
+                            try! tester.connection1.readWriteTransaction { transaction, collections in
+                                let collection = transaction.readWrite(collections.wheels)
                                 collection.setValue(expectedWheel, forKey: expectedWheel.uuid)
                             }
 
                             var fetchedWheel: WheelModel?
 
-                            try! tester.connection1.readWriteTransaction { transaction in
-                                let collection = transaction.readOnly(tester.collections.wheels)
+                            try! tester.connection1.readWriteTransaction { transaction, collections in
+                                let collection = transaction.readOnly(collections.wheels)
                                 fetchedWheel = collection.valueForKey("test_1")
                             }
 
@@ -221,15 +221,15 @@ class BasicRegressionTests: QuickSpec {
                         it("successfully writes a model and can read it back") {
                             let expectedWheel = WheelModel(uuid: "test_1", manufacturer: "Pirelli", size: 18.0)
 
-                            try! tester.connection1.readWriteTransaction { transaction in
-                                let collection = transaction.readWrite(tester.collections.wheels)
+                            try! tester.connection1.readWriteTransaction { transaction, collections in
+                                let collection = transaction.readWrite(collections.wheels)
                                 collection.setValue(expectedWheel, forKey: expectedWheel.uuid)
                             }
 
                             var fetchedWheel: WheelModel?
 
-                            try! tester.connection2.readWriteTransaction { transaction in
-                                let collection = transaction.readWrite(tester.collections.wheels)
+                            try! tester.connection2.readWriteTransaction { transaction, collections in
+                                let collection = transaction.readWrite(collections.wheels)
                                 fetchedWheel = collection.valueForKey("test_1")
                             }
 
@@ -244,15 +244,15 @@ class BasicRegressionTests: QuickSpec {
                         it("successfully writes a model and can read it back") {
                             let expectedWheel = WheelModel(uuid: "test_1", manufacturer: "Pirelli", size: 18.0)
 
-                            try! tester.connection1.readWriteTransaction { transaction in
-                                let collection = transaction.readWrite(tester.collections.wheels)
+                            try! tester.connection1.readWriteTransaction { transaction, collections in
+                                let collection = transaction.readWrite(collections.wheels)
                                 collection.setValue(expectedWheel, forKey: expectedWheel.uuid)
                             }
 
                             var fetchedWheel: WheelModel?
 
-                            try! tester.connection2.readWriteTransaction { transaction in
-                                let collection = transaction.readOnly(tester.collections.wheels)
+                            try! tester.connection2.readWriteTransaction { transaction, collections in
+                                let collection = transaction.readOnly(collections.wheels)
                                 fetchedWheel = collection.valueForKey("test_1")
                             }
 

--- a/TurfRegressionTests/Common/CarsCollection.swift
+++ b/TurfRegressionTests/Common/CarsCollection.swift
@@ -8,7 +8,7 @@ class CarsCollection: Collection {
     let schemaVersion = UInt64(1)
     let valueCacheSize: Int? = nil
 
-    func setUp(transaction: ReadWriteTransaction) throws {
+    func setUp<DatabaseCollections: CollectionsContainer>(transaction: ReadWriteTransaction<DatabaseCollections>) throws {
         try transaction.registerCollection(self)
     }
 

--- a/TurfRegressionTests/Common/Collections.swift
+++ b/TurfRegressionTests/Common/Collections.swift
@@ -4,7 +4,7 @@ final class Collections: CollectionsContainer {
     let cars = CarsCollection()
     let wheels = WheelsCollection()
 
-    func setUpCollections(transaction transaction: ReadWriteTransaction) throws {
+    func setUpCollections(transaction transaction: ReadWriteTransaction<Collections>) throws {
         try cars.setUp(transaction)
         try wheels.setUp(transaction)
     }

--- a/TurfRegressionTests/Common/TestDatabase.swift
+++ b/TurfRegressionTests/Common/TestDatabase.swift
@@ -1,11 +1,11 @@
 import Turf
 
 final class TestDatabase {
-    let database: Database
+    let database: Database<Collections>
     let collections: Collections
-    let connection1: Connection
-    let connection2: Connection
-    private(set) var observingConnection: ObservingConnection!
+    let connection1: Connection<Collections>
+    let connection2: Connection<Collections>
+    private(set) var observingConnection: ObservingConnection<Collections>!
 
     init(databasePath: String) throws {
         self.collections = Collections()

--- a/TurfRegressionTests/Common/WheelsCollection.swift
+++ b/TurfRegressionTests/Common/WheelsCollection.swift
@@ -8,7 +8,7 @@ class WheelsCollection: Collection {
     let schemaVersion = UInt64(1)
     let valueCacheSize: Int? = nil
 
-    func setUp(transaction: ReadWriteTransaction) throws {
+    func setUp<DatabaseCollections: CollectionsContainer>(transaction: ReadWriteTransaction<DatabaseCollections>) throws {
         try transaction.registerCollection(self)
     }
 


### PR DESCRIPTION
This greatly improves the usability of the API in "real world" apps and also keeps databases strongly typed. You don't have to pass a `CollectionsContainer` or `Collection` object into every method.

``` swift
try readWriteConnection.readWriteTransaction { transaction, collections in
     transaction.readWrite(collections.cars).removeAllValues()
     transaction.readWrite(collections.wheels).removeAllValues()
}
```

It comes with the sacrifice of code readability and the `ObserverOf` definitely took a hit - this is prime for a refactor asap.
